### PR TITLE
update similarity metric into create index endpoint

### DIFF
--- a/examples/text_search.py
+++ b/examples/text_search.py
@@ -39,9 +39,6 @@ if __name__ == '__main__':
     # Step 2. Index item one by one
     index_vectors(test_index_name)
 
-    # Sleep 30 seconds to build index.
-    time.sleep(30)
-
     query_vector = model.encode("test").tolist()
     start = time.time()
     response = VECTORSTORE_CLIENT.query(test_index_name, query_vector, 20,

--- a/examples/text_search.py
+++ b/examples/text_search.py
@@ -34,7 +34,7 @@ if __name__ == '__main__':
 
     test_dimension = 768
     # Step 1. Create index
-    VECTORSTORE_CLIENT.create_index(test_index_name, test_dimension, 100000)
+    VECTORSTORE_CLIENT.create_index(test_index_name, test_dimension, 100000, "l2")
 
     # Step 2. Index item one by one
     index_vectors(test_index_name)

--- a/examples/text_search.py
+++ b/examples/text_search.py
@@ -39,6 +39,7 @@ if __name__ == '__main__':
     # Step 2. Index item one by one
     index_vectors(test_index_name)
 
+    # Step 3. Query index to get similar results.
     query_vector = model.encode("test").tolist()
     start = time.time()
     response = VECTORSTORE_CLIENT.query(test_index_name, query_vector, 20,
@@ -47,5 +48,5 @@ if __name__ == '__main__':
     end = time.time()
     print(end - start)
 
-    # Step 3. Delete index
+    # Step 4. Delete index
     # VECTORSTORE_CLIENT.delete_index(test_index_name)

--- a/examples/us_states_metadata_filtering.py
+++ b/examples/us_states_metadata_filtering.py
@@ -93,9 +93,6 @@ if __name__ == '__main__':
     # commented out.
     batch_index_vectors(test_index_name, test_max_id, test_dimension)
 
-    # Sleep 30 seconds to build index.
-    time.sleep(30)
-
     # step 4: Generate a vector to query the test_index_name in the Vectorstore
     # query_vector = get_random_vector(test_dimension)
     query_vector = get_all_half_vector(test_dimension)

--- a/examples/us_states_metadata_filtering.py
+++ b/examples/us_states_metadata_filtering.py
@@ -86,7 +86,7 @@ if __name__ == '__main__':
     # than the number of vectors specified as test_max_id.
     # This step is only needed once when creating index. After the index is created, this line can be
     # commented out.
-    VECTORSTORE_CLIENT.create_index(test_index_name, test_dimension, 100000)
+    VECTORSTORE_CLIENT.create_index(test_index_name, test_dimension, 100000, "l2")
 
     # Step 3: Batch index vectors
     # This step is only needed once in this example. After the index is finished, this line can be

--- a/src/vectorstore_client.py
+++ b/src/vectorstore_client.py
@@ -18,12 +18,17 @@ class VectorstoreClient:
         self.headers = {"api_key": api_key, 'Content-type': 'application/json'}
 
     # Link: https://docs.google.com/document/d/1kwZr28YJa_baLFfd3ii2dvnHzY__rwCg1KiUq3QPeJU/edit#heading=h.r3ld8u9wfcqr
-    def create_index(self, index_name, dimension, max_num_vectors):
+    # similarity_metric only allows three options: l2, ip, cosine
+    # l2 -> Squared L2
+    # ip -> inner product distance = 1 - inner product of two vectors
+    # cosine -> cosine similarity distance = 1 - cosine of two vectors
+    def create_index(self, index_name, dimension, max_num_vectors, similarity_metric):
         create_index_endpoint = self.host_name + "/create_index"
         data = {
             "index_name": index_name,
             "dimension": dimension,
-            "max_num_vectors": max_num_vectors
+            "max_num_vectors": max_num_vectors,
+            "similarity_metric": similarity_metric
         }
 
         return requests.post(create_index_endpoint, headers=self.headers, json=data)


### PR DESCRIPTION
This PR enables customers to specify similarity metric (similarity_metric only allows three options: l2, ip, cosine) in the create index endpoint. For the details of similarity metrics, please check https://medium.com/@junxie2/semantic-search-similarity-metrics-e215a0d65885.